### PR TITLE
Fix API CLI and report generation bug

### DIFF
--- a/docs_tc.py
+++ b/docs_tc.py
@@ -80,8 +80,18 @@ def main():
 
     # --- Subparser para configuração da API ---
     parser_api = subparsers.add_parser("api", help="Configura a chave da API do Google Gemini.")
-    parser_api.add_argument("api_key", help="Chave da API do Google Gemini para ser salva globalmente.")
-    parser_api.add_argument("--show", action="store_true", help="Mostra a chave da API atual (parcialmente mascarada).")
+    # Torna o argumento da chave opcional para permitir 'docs-cli api --show'
+    parser_api.add_argument(
+        "api_key",
+        nargs="?",
+        default=None,
+        help="Chave da API do Google Gemini para ser salva globalmente."
+    )
+    parser_api.add_argument(
+        "--show",
+        action="store_true",
+        help="Mostra a chave da API atual (parcialmente mascarada)."
+    )
 
     # --- Subparser para merge_markdown.py ---
     parser_merge = subparsers.add_parser("merge", help="Consolida arquivos Markdown de um diretório.")
@@ -185,10 +195,13 @@ def main():
                 print(f"Chave da API atual: {masked_key}")
             else:
                 print("Nenhuma chave da API configurada.")
-        else:
+        elif args.api_key:
             config["api_key"] = args.api_key
             save_config(config)
             print("✅ Chave da API configurada com sucesso!")
+        else:
+            print("É necessário fornecer a chave da API ou usar --show para exibir a chave atual.")
+            parser_api.print_help()
         return
 
     # Usa a chave da API da configuração se não for fornecida via linha de comando

--- a/generate_report.py
+++ b/generate_report.py
@@ -76,12 +76,15 @@ def generate_md_report(evaluation_json_path="evaluation_results.json", output_md
         md_content += f"#### Top {top_k_chunks} Chunks Relevantes para a Pergunta:\n\n"
         if item.get('top_k_chunks_relevantes'):
             for chunk in item['top_k_chunks_relevantes']:
-                md_content += f"""* **Documento:** {chunk['document_title']}
+                preview = chunk['content_preview'].replace('`', '\\`')
+                md_content += (
+                    f"""* **Documento:** {chunk['document_title']}
     * **Seção:** {chunk['chunk_title']}
     * **Caminho do Arquivo:** `{chunk['filepath']}`
     * **Similaridade com a Pergunta:** {chunk['similarity_to_query']}
-    * **Conteúdo (preview):** `{chunk['content_preview'].replace('`', '\\`')}`
+    * **Conteúdo (preview):** `{preview}`
 """
+                )
             md_content += "\n" # Adiciona uma linha em branco para espaçamento
         else:
             md_content += "* Nenhum chunk relevante encontrado.\n\n"


### PR DESCRIPTION
## Summary
- make API key argument optional for `docs-cli api`
- handle missing API key when `--show` is not used
- escape content preview separately in markdown report

## Testing
- `python -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_68406b52da948333a5e8faf1fe3a9045