### PR TITLE
Fix embedding spelling comment

### DIFF
--- a/docs_tc.py
+++ b/docs_tc.py
@@ -96,7 +96,7 @@ def main():
     parser_extract.add_argument("--output_file", default=DEFAULT_RAW_DOCS,
                                 help=f"Arquivo JSON de saída para os documentos brutos (padrão: {DEFAULT_RAW_DOCS}).")
 
-    # --- Subparser para generate_embedings.py ---
+    # --- Subparser para generate_embeddings.py ---
     parser_generate = subparsers.add_parser("generate_embeddings", help="Gera embeddings para os documentos processados.")
     parser_generate.add_argument("--input_file", default=DEFAULT_RAW_DOCS,
                                  help=f"Arquivo JSON de entrada com os documentos brutos (padrão: {DEFAULT_RAW_DOCS}).")


### PR DESCRIPTION
## Summary
- correct typo in docs_tc comment referencing generate_embeddings.py

## Testing
- `python3 -m py_compile docs_tc.py generate_embeddings.py generate_report.py generate_report_html.py evaluate_coverage.py extract_data_from_markdown.py limpa_csv.py merge_markdown.py` *(fails: SyntaxError in generate_report.py)*

------
https://chatgpt.com/codex/tasks/task_e_68406cb49c948333837977a6e7d746d8