### PR TITLE
Centralize Gemini API key handling

### DIFF
--- a/docs_tc.py
+++ b/docs_tc.py
@@ -247,13 +247,18 @@ def main():
     elif args.command == "clean_csv":
         run_script([SCRIPT_MAP["clean_csv"], args.input_file, args.output_file])
     elif args.command == "evaluate":
-        run_script([
+        command_args = [
             SCRIPT_MAP["evaluate"],
             args.qa_file,
             args.embeddings_file,
-            "-k", str(args.top_k),
-            "-o", args.output
-        ])
+            "-k",
+            str(args.top_k),
+            "-o",
+            args.output,
+        ]
+        if api_key:
+            command_args.extend(["--gemini-api-key", api_key])
+        run_script(command_args)
     elif args.command == "report_md":
         run_script([
             SCRIPT_MAP["report_md"],
@@ -284,14 +289,19 @@ def main():
         if api_key:
             generate_embeddings_args.extend(["--gemini-api-key", api_key])
         run_step_or_exit(generate_embeddings_args)
-        
-        run_step_or_exit([
+
+        evaluate_args = [
             SCRIPT_MAP["evaluate"],
             args.cleaned_qa_file,
             args.embeddings_file,
-            "-k", str(args.eval_top_k),
-            "-o", args.eval_results_file
-        ])
+            "-k",
+            str(args.eval_top_k),
+            "-o",
+            args.eval_results_file,
+        ]
+        if api_key:
+            evaluate_args.extend(["--gemini-api-key", api_key])
+        run_step_or_exit(evaluate_args)
         run_step_or_exit([
             SCRIPT_MAP["report_md"],
             args.eval_results_file,
@@ -369,12 +379,18 @@ def main():
                 if not os.path.exists(current_embeddings_file):
                      current_embeddings_file = input(f"Arquivo de Embeddings ({current_embeddings_file}) não encontrado. Informe o caminho correto: ")
                 eval_k_str = input(f"Informe o top_k para evaluate (pressione Enter para usar {default_eval_top_k}): ") or str(default_eval_top_k)
-                run_custom_step_or_exit([
+                eval_args = [
                     SCRIPT_MAP["evaluate"],
-                    current_cleaned_qa_file, current_embeddings_file,
-                    "-k", eval_k_str,
-                    "-o", current_eval_results_file
-                ])
+                    current_cleaned_qa_file,
+                    current_embeddings_file,
+                    "-k",
+                    eval_k_str,
+                    "-o",
+                    current_eval_results_file,
+                ]
+                if api_key:
+                    eval_args.extend(["--gemini-api-key", api_key])
+                run_custom_step_or_exit(eval_args)
             elif step == "report_md":
                  if not os.path.exists(current_eval_results_file):
                      current_eval_results_file = input(f"Arquivo de Resultados da Avaliação ({current_eval_results_file}) não encontrado. Informe o caminho correto: ")

--- a/generate_embeddings.py
+++ b/generate_embeddings.py
@@ -4,14 +4,10 @@ import json
 import os
 import google.generativeai as genai
 import openai
-from dotenv import load_dotenv
 import time
 import re
 import requests  # Adicionado para DeepInfra
 import sys  # Garantir importação para uso em cli_main()
-
-# Carrega as variáveis de ambiente do arquivo .env
-load_dotenv()
 
 # --- Configuração de Modelos de Embedding para cada Provedor ---
 GEMINI_EMBEDDING_MODEL = "models/embedding-001"  # Modelo do Gemini
@@ -29,14 +25,14 @@ gemini_request_count = 0
 gemini_last_request_time = time.time()
 
 def configure_api(api_key=None):
-    """
-    Configura a API do Google Gemini com a chave fornecida ou da variável de ambiente.
-    """
-    global GOOGLE_API_KEY
-    GOOGLE_API_KEY = api_key or os.getenv("GOOGLE_API_KEY")
-    if not GOOGLE_API_KEY:
-        raise ValueError("A chave da API do Google Gemini não está configurada. Use --api-key ou configure GOOGLE_API_KEY no arquivo .env")
-    genai.configure(api_key=GOOGLE_API_KEY) # type: ignore
+    """Configura o Google Gemini usando a chave fornecida ou a variável de ambiente."""
+    key = api_key or os.getenv("GOOGLE_API_KEY")
+    if not key:
+        raise ValueError(
+            "A chave da API do Google Gemini não está configurada. "
+            "Passe via argumento ou defina GOOGLE_API_KEY."
+        )
+    genai.configure(api_key=key)  # type: ignore
 
 def clean_text_for_embedding(text):
     """


### PR DESCRIPTION
## Summary
- stop loading `.env` directly in `generate_embeddings.py`
- allow `evaluate_coverage.py` to receive a Gemini API key and configure `genai`
- pass the API key from the orchestrator when running `evaluate_coverage`
- support API key forwarding in `full_flow` and custom flows

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684085f420a88333ba719107d5e2747f