### PR TITLE
Improve error handling

### DIFF
--- a/evaluate_coverage.py
+++ b/evaluate_coverage.py
@@ -10,6 +10,7 @@ import numpy as np  # Para cálculo de similaridade de cosseno
 import re  # Para manipulação de texto e divisão de frases
 import argparse  # Adicionado para parsing de argumentos CLI
 import sys  # Adicionado para sys.exit
+from exceptions import MinhaExcecaoEspecifica
 
 from utils import (
     clean_text_for_embedding,
@@ -295,11 +296,11 @@ def cli_main():
         qa_filepath=args.qa_filepath,
         chunks_filepath=args.embeddings_filepath,
         top_k_chunks=args.top_k_chunks,
-        output_json_path=args.output
+        output_json_path=args.output,
     )
     if not success:
         print("\nA avaliação de cobertura da documentação falhou.")
-        sys.exit(1)
+        raise MinhaExcecaoEspecifica("Falha em evaluate_coverage")
     else:
         print("\nA avaliação de cobertura da documentação foi concluída com sucesso.")
 

--- a/exceptions.py
+++ b/exceptions.py
@@ -1,0 +1,3 @@
+class MinhaExcecaoEspecifica(Exception):
+    """Erro específico para scripts do Docs CLI Toolkit."""
+    pass

--- a/extract_data_from_markdown.py
+++ b/extract_data_from_markdown.py
@@ -2,6 +2,7 @@
 import re
 import json
 import os
+from exceptions import MinhaExcecaoEspecifica
 
 def extract_docs_from_consolidated_md(input_md_path="corpus_consolidated.md", output_json_path="raw_docs.json"):
     """
@@ -119,7 +120,7 @@ def cli_main():
     success = extract_docs_from_consolidated_md(args.input_md_path, args.output_json_path)
     if not success:
         print("A extração de documentos do MD consolidado falhou.")
-        sys.exit(1)
+        raise MinhaExcecaoEspecifica("Falha em extract_data_from_markdown")
     else:
         print("Extração de documentos do MD consolidado concluída com sucesso.")
 

--- a/generate_embeddings.py
+++ b/generate_embeddings.py
@@ -9,6 +9,7 @@ import time
 import re
 import requests  # Adicionado para DeepInfra
 import sys  # Garantir importação para uso em cli_main()
+from exceptions import MinhaExcecaoEspecifica
 
 from utils import (
     clean_text_for_embedding,
@@ -289,7 +290,7 @@ def cli_main():
     )
     if not success:
         print("A geração de embeddings falhou.")
-        sys.exit(1)
+        raise MinhaExcecaoEspecifica("Falha em generate_embeddings")
     else:
         print("Geração de embeddings concluída com sucesso.")
 

--- a/generate_report.py
+++ b/generate_report.py
@@ -3,6 +3,7 @@
 import json
 import os
 from datetime import datetime
+from exceptions import MinhaExcecaoEspecifica
 
 def generate_md_report(evaluation_json_path="evaluation_results.json", output_md_path="coverage_report.md", top_k_chunks=5):
     """
@@ -116,6 +117,6 @@ if __name__ == "__main__":
     )
     if not success:
         print("A geração do relatório Markdown falhou.")
-        sys.exit(1)
+        raise MinhaExcecaoEspecifica("Falha em generate_report")
     else:
         print("Geração do relatório Markdown concluída com sucesso.")

--- a/generate_report_html.py
+++ b/generate_report_html.py
@@ -5,6 +5,7 @@ import os
 from datetime import datetime
 import argparse # Make sure argparse is imported
 import sys      # Make sure sys is imported
+from exceptions import MinhaExcecaoEspecifica
 
 # ... (keep your generate_html_report function as is) ...
 def generate_html_report(evaluation_json_path="evaluation_results.json", output_html_path="coverage_report.html", top_k_chunks=5):
@@ -196,7 +197,7 @@ def cli_main():
     )
     if not success:
         print("A geração do relatório HTML falhou.")
-        sys.exit(1)
+        raise MinhaExcecaoEspecifica("Falha em generate_report_html")
     else:
         print("Geração do relatório HTML concluída com sucesso.")
 

--- a/limpa_csv.py
+++ b/limpa_csv.py
@@ -13,6 +13,7 @@ import os
 from pathlib import Path
 import argparse
 import sys
+from exceptions import MinhaExcecaoEspecifica
 import re
 
 def clean_text(text):
@@ -204,7 +205,7 @@ def cli_main():
     
     if not os.path.exists(args.input_file):
         print(f"❌ Arquivo '{args.input_file}' não encontrado!")
-        sys.exit(1)
+        raise MinhaExcecaoEspecifica("Entrada de arquivo CSV não encontrado")
     
     stats = clean_csv_data(
         input_file=args.input_file,
@@ -221,7 +222,7 @@ def cli_main():
         print_summary(stats)
     else:
         print("❌ Falha no processamento do arquivo!")
-        sys.exit(1)
+        raise MinhaExcecaoEspecifica("Falha em limpa_csv")
 
 if __name__ == "__main__":
     cli_main()


### PR DESCRIPTION
## Summary
- define `MinhaExcecaoEspecifica` for script errors
- raise the custom exception from individual scripts instead of calling `sys.exit`
- let `docs_tc.run_script` catch these exceptions when calling modules

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684087bcb5208333aaf6535f9ed0c2ce