### PR TITLE
Add style checker agent

### DIFF
--- a/Agents.md
+++ b/Agents.md
@@ -163,7 +163,7 @@ _Se houver outras credenciais (por ex., chaves para repositório, tokens de CI/C
 
 ---
 
-### 4.3 Agent de Relatório / Reporting Agent  
+### 4.3 Agent de Relatório / Reporting Agent
 - **Nome do Agente / Agent Name:**  
   ```
   report_generator
@@ -193,7 +193,40 @@ _Se houver outras credenciais (por ex., chaves para repositório, tokens de CI/C
      - _Saída:_ String contendo todo o conteúdo em Markdown.  
   2. `generate_html(evaluation_json: str) -> str`  
      - _Entrada:_ Mesma do método acima.  
-     - _Saída:_ String em HTML formatado.  
+    - _Saída:_ String em HTML formatado.
+
+---
+
+### 4.4 Agent de Verificação de Estilo / Style Checker Agent
+- **Nome do Agente / Agent Name:**
+  ```
+  style_checker
+  ```
+- **Responsabilidade / Responsibility:**
+  - Carregar embeddings do guia de estilo.
+  - Gerar embedding para o texto submetido.
+  - Calcular similaridade e apontar sentenças fora do padrão.
+- **Código de Instanciação / Instantiation Code:**
+  ```python
+  from codex_agents import StyleCheckerAgent
+
+  style_agent = StyleCheckerAgent(
+      embeddings_path="style_embeddings.json",
+      api_key=os.getenv("GOOGLE_API_KEY"),
+      threshold=0.8
+  )
+  ```
+- **Parâmetros de Inicialização / Initialization Parameters:**
+  | Parâmetro        | Tipo   | Descrição                                                     | Padrão                     |
+  |------------------|--------|---------------------------------------------------------------|----------------------------|
+  | `embeddings_path`| string | Caminho para JSON de embeddings do guia de estilo             | `"style_embeddings.json"` |
+  | `api_key`        | string | Chave da API para gerar embeddings em tempo real              | `GOOGLE_API_KEY`           |
+  | `threshold`      | float  | Similaridade mínima aceita para considerar frase no padrão    | `0.8`                      |
+
+- **Métodos Principais / Main Methods:**
+  1. `check(text: str) -> List[Dict[str, Any]]`
+     - _Entrada:_ Texto livre.
+     - _Saída:_ Lista de sentenças com similaridade abaixo do limiar.
 
 ---
 
@@ -260,7 +293,8 @@ docs-cli report_html --input_file evaluation_results.json --output_file coverage
 |------------|--------|-------------------------------------------------------------|---------------|
 | 2025-06-04 | 1.0    | Criação inicial de Agents.md contendo 3 definições de agente | Paulo Duarte  |
 | 2025-06-10 | 1.1    | Adicionado Agent de Reporting e seção de Notas e Best Practices | Paulo Duarte  |
-| `YYYY-MM-DD` | X.Y  | Breve descrição da mudança                                   | Seu Nome      |
+| 2025-06-15 | 1.2    | Adicionado Agent de Verificação de Estilo | Paulo Duarte  |
+| `YYYY-MM-DD` | X.Y  | Breve descrição da mudança      | Seu Nome      |
 
 ---
 

--- a/docs_tc.py
+++ b/docs_tc.py
@@ -204,6 +204,13 @@ def main():
     parser_report_html.add_argument("--top_k_chunks", type=int, default=5,
                                     help="Valor de top_k_chunks usado na avaliação (para consistência do relatório, padrão: 5).")
 
+    # --- Subparser para style_checker.py ---
+    parser_style = subparsers.add_parser("style_check", help="Verifica o estilo de um texto.")
+    parser_style.add_argument("input_file", help="Arquivo de texto a ser analisado.")
+    parser_style.add_argument("embeddings_file", help="Arquivo JSON com embeddings do guia de estilo.")
+    parser_style.add_argument("threshold", type=float, default=0.8, help="Similaridade mínima (padrão: 0.8).")
+    parser_style.add_argument("--api_key", help="Chave da API opcional.")
+
     # --- Subparser para o fluxo completo ---
     parser_full_flow = subparsers.add_parser("full_flow", help="Executa o fluxo completo de processamento e avaliação.")
     parser_full_flow.add_argument("doc_input_dir", help="Diretório de entrada dos arquivos .md originais.")
@@ -256,7 +263,8 @@ def main():
         "clean_csv": "docs-tc-clean-csv",
         "evaluate": "docs-tc-evaluate-coverage",
         "report_md": "docs-tc-generate-report-md",
-        "report_html": "docs-tc-generate-report-html"
+        "report_html": "docs-tc-generate-report-html",
+        "style_check": "docs-tc-style-checker"
     }
 
     if args.command == "merge":
@@ -300,6 +308,16 @@ def main():
             args.output_file,
             str(args.top_k_chunks),
         ], verbose=args.verbose)
+    elif args.command == "style_check":
+        command_args = [
+            SCRIPT_MAP["style_check"],
+            args.input_file,
+            args.embeddings_file,
+            str(args.threshold),
+        ]
+        if args.api_key:
+            command_args.extend(["--api_key", args.api_key])
+        run_script(command_args, verbose=args.verbose)
     elif args.command == "full_flow":
         print("🚀 Iniciando fluxo completo...")
         def run_step_or_exit(step_command_args):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ docs-tc-clean-csv = "limpa_csv:cli_main"
 docs-tc-evaluate-coverage = "evaluate_coverage:cli_main"
 docs-tc-generate-report-md = "generate_report:cli_main"
 docs-tc-generate-report-html = "generate_report_html:cli_main"
+docs-tc-style-checker = "style_checker:cli_main"
 
 [project.urls]
 Homepage = "https://github.com/seu-usuario/docs-cli-toolkit"

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ setup(
         "evaluate_coverage",
         "generate_report",
         "generate_report_html",
+        "style_checker",
     ]
     # Não é necessário entry_points aqui se todos estiverem no pyproject.toml [project.scripts]
     # Não é necessário install_requires aqui se estiver no pyproject.toml [project.dependencies]

--- a/style_checker.py
+++ b/style_checker.py
@@ -1,0 +1,99 @@
+import json
+import os
+import re
+import argparse
+import sys
+from typing import List, Dict, Any
+
+
+from utils import (
+    clean_text_for_embedding,
+    generate_embedding_with_retry,
+    GEMINI_EMBEDDING_MODEL,
+)
+
+
+def cosine_similarity(vec_a: List[float], vec_b: List[float]) -> float:
+    """Calcula a similaridade de cosseno entre dois vetores."""
+    if not vec_a or not vec_b or len(vec_a) != len(vec_b):
+        return 0.0
+    dot = sum(a * b for a, b in zip(vec_a, vec_b))
+    norm_a = sum(a * a for a in vec_a) ** 0.5
+    norm_b = sum(b * b for b in vec_b) ** 0.5
+    if norm_a == 0 or norm_b == 0:
+        return 0.0
+    return float(dot / (norm_a * norm_b))
+
+
+def check_style(
+    text: str,
+    embeddings_path: str = "style_embeddings.json",
+    api_key: str | None = None,
+    threshold: float = 0.8,
+) -> List[Dict[str, Any]]:
+    """Analisa o texto e retorna sentenças fora do padrão de estilo."""
+    if not os.path.exists(embeddings_path):
+        raise FileNotFoundError(f"Embeddings file '{embeddings_path}' not found")
+
+    with open(embeddings_path, "r", encoding="utf-8") as f:
+        style_data = json.load(f)
+
+    sentences = [s.strip() for s in re.split(r"[.!?]+", text) if s.strip()]
+    flagged: List[Dict[str, Any]] = []
+    for sentence in sentences:
+        clean_sentence = clean_text_for_embedding(sentence)
+        embedding = generate_embedding_with_retry(
+            clean_sentence, api_key or os.getenv("GOOGLE_API_KEY"), model=GEMINI_EMBEDDING_MODEL
+        )
+        if embedding is None:
+            continue
+        best_sim = 0.0
+        for item in style_data:
+            style_emb = item.get("embedding")
+            if style_emb:
+                sim = cosine_similarity(embedding, style_emb)
+                if sim > best_sim:
+                    best_sim = sim
+        if best_sim < threshold:
+            flagged.append({"sentence": sentence, "similarity": best_sim})
+    return flagged
+
+
+def cli_main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Verifica conformidade de estilo de um texto usando embeddings."
+    )
+    parser.add_argument("input_file", help="Arquivo de texto a verificar")
+    parser.add_argument(
+        "embeddings_file",
+        help="Arquivo JSON com embeddings do guia de estilo",
+    )
+    parser.add_argument(
+        "threshold",
+        type=float,
+        help="Similaridade mínima para considerar frase no padrão",
+    )
+    parser.add_argument(
+        "--api_key",
+        help="Chave de API opcional (senão usa GOOGLE_API_KEY do ambiente)",
+    )
+    args = parser.parse_args()
+
+    with open(args.input_file, "r", encoding="utf-8") as f:
+        text = f.read()
+
+    issues = check_style(
+        text,
+        embeddings_path=args.embeddings_file,
+        api_key=args.api_key,
+        threshold=args.threshold,
+    )
+    print(json.dumps(issues, ensure_ascii=False, indent=2))
+    if issues:
+        print("Trechos fora do padrão encontrados.")
+    else:
+        print("Nenhum problema de estilo encontrado.")
+
+
+if __name__ == "__main__":
+    cli_main()

--- a/tests/test_docs_tc.py
+++ b/tests/test_docs_tc.py
@@ -42,3 +42,31 @@ def test_main_merge_invokes_run_script(monkeypatch, tmp_path):
     docs_tc.main()
     assert called["cmd"] == ["docs-tc-merge-markdown", "docsdir", "out.md"]
 
+
+def test_main_style_check_invokes_run_script(monkeypatch, tmp_path):
+    called = {}
+    def fake_run_script(cmd, verbose=False):
+        called["cmd"] = cmd
+        return True
+    monkeypatch.setattr(docs_tc, "run_script", fake_run_script)
+    monkeypatch.setattr(docs_tc, "CONFIG_DIR", tmp_path)
+    monkeypatch.setattr(docs_tc, "CONFIG_FILE", tmp_path / "config.json")
+    monkeypatch.setattr(sys, "argv", [
+        "docs_tc.py",
+        "style_check",
+        "in.txt",
+        "style.json",
+        "0.9",
+        "--api_key",
+        "KEY",
+    ])
+    docs_tc.main()
+    assert called["cmd"] == [
+        "docs-tc-style-checker",
+        "in.txt",
+        "style.json",
+        "0.9",
+        "--api_key",
+        "KEY",
+    ]
+

--- a/tests/test_style_checker.py
+++ b/tests/test_style_checker.py
@@ -1,0 +1,45 @@
+import json
+from pathlib import Path
+import types
+import sys
+
+fake_numpy = types.ModuleType("numpy")
+fake_numpy.array = lambda x: x
+fake_numpy.dot = lambda a, b: sum(i * j for i, j in zip(a, b))
+fake_numpy.linalg = types.SimpleNamespace(norm=lambda v: sum(x * x for x in v) ** 0.5)
+sys.modules.setdefault("numpy", fake_numpy)
+fake_google = types.ModuleType("google")
+fake_genai = types.ModuleType("google.generativeai")
+setattr(fake_genai, "embed_content", lambda model=None, content=None: {"embedding": [1.0, 0.0]})
+fake_google.generativeai = fake_genai
+sys.modules.setdefault("google", fake_google)
+sys.modules.setdefault("google.generativeai", fake_genai)
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+import style_checker
+
+
+def test_cosine_similarity_basic():
+    a = [1.0, 0.0]
+    b = [0.0, 1.0]
+    assert style_checker.cosine_similarity(a, b) == 0.0
+
+
+def test_check_style_flags_sentence(monkeypatch, tmp_path):
+    emb_file = tmp_path / "emb.json"
+    with open(emb_file, "w", encoding="utf-8") as f:
+        json.dump([{"text": "ok", "embedding": [1.0, 0.0]}], f)
+
+    def fake_embed(text, api_key, model=None):
+        if "bad" in text:
+            return [0.0, 1.0]
+        return [1.0, 0.0]
+
+    monkeypatch.setattr(style_checker, "generate_embedding_with_retry", fake_embed)
+
+    text = "good sentence. bad style."
+    issues = style_checker.check_style(text, str(emb_file), api_key="X", threshold=0.8)
+    assert len(issues) == 1
+    assert issues[0]["sentence"] == "bad style"


### PR DESCRIPTION
## Summary
- create `style_checker.py` to verify text against style guide embeddings
- integrate new `style_check` subcommand in `docs_tc.py`
- document Style Checker agent in `Agents.md`
- register CLI entry point in setup files
- add unit tests for style checker and CLI mapping

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68458ec496588333a8f63a126c1efcec