### PR TITLE
Improve .env integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,6 @@
+# Exemplo de chaves de API
+# Defina apenas a chave do provedor desejado
+OPENAI_API_KEY=your-openai-key
+GOOGLE_API_KEY=your-gemini-key
+DEEPINFRA_API_KEY=your-deepinfra-key
+

--- a/README.md
+++ b/README.md
@@ -37,11 +37,13 @@ A ferramenta oferece três maneiras de configurar as chaves das APIs do Google G
 
 3. **Via Variável de Ambiente:**
    Crie um arquivo `.env` no diretório do projeto:
-   ```
-   GOOGLE_API_KEY=sua-chave-gemini
-   DEEPINFRA_API_KEY=sua-chave-deepinfra
-   OPENAI_API_KEY=sua-chave-openai
+ ```
+  GOOGLE_API_KEY=sua-chave-gemini
+  DEEPINFRA_API_KEY=sua-chave-deepinfra
+  OPENAI_API_KEY=sua-chave-openai
   ```
+  Um arquivo `/.env.example` está disponível com esse formato.
+  Se você não especificar `--provider`, o comando escolhe automaticamente `openai` quando `OPENAI_API_KEY` estiver definido; caso contrário usa o Gemini.
 
 ## Comandos Disponíveis
 

--- a/style_checker.py
+++ b/style_checker.py
@@ -1,9 +1,16 @@
 import json
 import os
+try:
+    from dotenv import load_dotenv
+except Exception:  # pragma: no cover - fallback if dotenv not installed
+    def load_dotenv(*_args, **_kwargs):
+        return None
 import re
 import argparse
 import sys
 from typing import List, Dict, Any
+
+load_dotenv()
 
 
 from utils import (


### PR DESCRIPTION
## Summary
- allow using `.env` file with automatic provider choice
- handle missing `python-dotenv`
- support OpenAI embeddings for coverage evaluation
- document `.env.example`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849c1157c48833384ed938c1b12bbac