### PR TITLE
Standardize CLI argument style

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,25 +50,25 @@ A ferramenta oferece três maneiras de configurar as chaves das APIs do Google G
 ### 1. Merge de Documentos
 Consolida múltiplos arquivos Markdown em um único arquivo:
 ```bash
-docs-cli merge <diretório_entrada> [--output_file arquivo_saída.md]
+docs-cli merge <diretório_entrada> [arquivo_saída.md]
 ```
 
 ### 2. Extração de Dados
 Extrai dados estruturados do Markdown consolidado:
 ```bash
-docs-cli extract [--input_file arquivo_entrada.md] [--output_file arquivo_saída.json]
+docs-cli extract [arquivo_entrada.md] [arquivo_saída.json]
 ```
 
 ### 3. Geração de Embeddings
 Gera embeddings para os documentos processados:
 ```bash
 # Usando Gemini (padrão)
-docs-cli generate_embeddings [--input_file arquivo_entrada.json] [--output_file arquivo_saída.json]
+docs-cli generate_embeddings [arquivo_entrada.json] [arquivo_saída.json]
 
 # Usando DeepInfra/Maritaca
-docs-cli generate_embeddings --provider deepinfra --deepinfra-api-key "sua-chave" [--input_file arquivo_entrada.json] [--output_file arquivo_saída.json]
+docs-cli generate_embeddings --provider deepinfra --deepinfra-api-key "sua-chave" [arquivo_entrada.json] [arquivo_saída.json]
 # Usando OpenAI
-docs-cli generate_embeddings --provider openai --openai-api-key "sua-chave" [--input_file arquivo_entrada.json] [--output_file arquivo_saída.json]
+docs-cli generate_embeddings --provider openai --openai-api-key "sua-chave" [arquivo_entrada.json] [arquivo_saída.json]
 ```
 
 ### 4. Limpeza de CSV
@@ -111,10 +111,10 @@ docs-cli evaluate <arquivo_qa.csv> <arquivo_embeddings.json> [-k N] [-o arquivo_
 Gera relatórios em Markdown e HTML:
 ```bash
 # Relatório em Markdown
-docs-cli report_md [--input_file arquivo_entrada.json] [--output_file relatório.md] [--top_k_chunks N]
+docs-cli report_md [arquivo_entrada.json] [relatório.md] [top_k_chunks]
 
 # Relatório em HTML
-docs-cli report_html [--input_file arquivo_entrada.json] [--output_file relatório.html] [--top_k_chunks N]
+docs-cli report_html [arquivo_entrada.json] [relatório.html] [top_k_chunks]
 ```
 
 ### 7. Fluxo Completo
@@ -154,10 +154,10 @@ docs-cli --api "chave-temporária" custom_flow generate_embeddings
 ### Geração de Relatórios
 ```bash
 # Gerar relatório em Markdown
-docs-cli report_md --input_file evaluation_results.json --output_file coverage.md
+docs-cli report_md evaluation_results.json coverage.md
 
 # Gerar relatório em HTML
-docs-cli report_html --input_file evaluation_results.json --output_file coverage.html
+docs-cli report_html evaluation_results.json coverage.html
 ```
 
 ## Arquivos Intermediários

--- a/docs_tc.py
+++ b/docs_tc.py
@@ -130,24 +130,66 @@ def main():
     )
 
     # --- Subparser para merge_markdown.py ---
-    parser_merge = subparsers.add_parser("merge", help="Consolida arquivos Markdown de um diretório.")
-    parser_merge.add_argument("input_dir", help="Diretório de entrada contendo os arquivos .md.")
-    parser_merge.add_argument("--output_file", default=DEFAULT_CORPUS_CONSOLIDATED,
-                              help=f"Arquivo de saída para o Markdown consolidado (padrão: {DEFAULT_CORPUS_CONSOLIDATED}).")
+    parser_merge = subparsers.add_parser(
+        "merge",
+        help="Consolida arquivos Markdown de um diretório.",
+    )
+    parser_merge.add_argument(
+        "input_dir",
+        help="Diretório de entrada contendo os arquivos .md.",
+    )
+    parser_merge.add_argument(
+        "output_file",
+        nargs="?",
+        default=DEFAULT_CORPUS_CONSOLIDATED,
+        help=(
+            f"Arquivo de saída para o Markdown consolidado (padrão: {DEFAULT_CORPUS_CONSOLIDATED})."
+        ),
+    )
 
     # --- Subparser para extract_data_from_markdown.py ---
-    parser_extract = subparsers.add_parser("extract", help="Extrai dados estruturados do Markdown consolidado.")
-    parser_extract.add_argument("--input_file", default=DEFAULT_CORPUS_CONSOLIDATED,
-                                help=f"Arquivo Markdown consolidado de entrada (padrão: {DEFAULT_CORPUS_CONSOLIDATED}).")
-    parser_extract.add_argument("--output_file", default=DEFAULT_RAW_DOCS,
-                                help=f"Arquivo JSON de saída para os documentos brutos (padrão: {DEFAULT_RAW_DOCS}).")
+    parser_extract = subparsers.add_parser(
+        "extract",
+        help="Extrai dados estruturados do Markdown consolidado.",
+    )
+    parser_extract.add_argument(
+        "input_file",
+        nargs="?",
+        default=DEFAULT_CORPUS_CONSOLIDATED,
+        help=(
+            f"Arquivo Markdown consolidado de entrada (padrão: {DEFAULT_CORPUS_CONSOLIDATED})."
+        ),
+    )
+    parser_extract.add_argument(
+        "output_file",
+        nargs="?",
+        default=DEFAULT_RAW_DOCS,
+        help=(
+            f"Arquivo JSON de saída para os documentos brutos (padrão: {DEFAULT_RAW_DOCS})."
+        ),
+    )
 
     # --- Subparser para generate_embeddings.py ---
-    parser_generate = subparsers.add_parser("generate_embeddings", help="Gera embeddings para os documentos processados.")
-    parser_generate.add_argument("--input_file", default=DEFAULT_RAW_DOCS,
-                                 help=f"Arquivo JSON de entrada com os documentos brutos (padrão: {DEFAULT_RAW_DOCS}).")
-    parser_generate.add_argument("--output_file", default=DEFAULT_EMBEDDINGS,
-                                 help=f"Arquivo JSON de saída para os embeddings (padrão: {DEFAULT_EMBEDDINGS}).")
+    parser_generate = subparsers.add_parser(
+        "generate_embeddings",
+        help="Gera embeddings para os documentos processados.",
+    )
+    parser_generate.add_argument(
+        "input_file",
+        nargs="?",
+        default=DEFAULT_RAW_DOCS,
+        help=(
+            f"Arquivo JSON de entrada com os documentos brutos (padrão: {DEFAULT_RAW_DOCS})."
+        ),
+    )
+    parser_generate.add_argument(
+        "output_file",
+        nargs="?",
+        default=DEFAULT_EMBEDDINGS,
+        help=(
+            f"Arquivo JSON de saída para os embeddings (padrão: {DEFAULT_EMBEDDINGS})."
+        ),
+    )
     parser_generate.add_argument(
         "--provider",
         choices=["gemini", "deepinfra", "maritaca", "openai"],
@@ -193,22 +235,62 @@ def main():
                                  help=f"Arquivo de saída para os resultados da avaliação (padrão: {DEFAULT_EVAL_RESULTS}).")
 
     # --- Subparser para generate_report.py (Markdown) ---
-    parser_report_md = subparsers.add_parser("report_md", help="Gera o relatório de cobertura em Markdown.")
-    parser_report_md.add_argument("--input_file", default=DEFAULT_EVAL_RESULTS,
-                                  help=f"Arquivo JSON de entrada com os resultados da avaliação (padrão: {DEFAULT_EVAL_RESULTS}).")
-    parser_report_md.add_argument("--output_file", default=DEFAULT_MD_REPORT,
-                                  help=f"Arquivo Markdown de saída para o relatório (padrão: {DEFAULT_MD_REPORT}).")
-    parser_report_md.add_argument("--top_k_chunks", type=int, default=5,
-                                  help="Valor de top_k_chunks usado na avaliação (para consistência do relatório, padrão: 5).")
+    parser_report_md = subparsers.add_parser(
+        "report_md",
+        help="Gera o relatório de cobertura em Markdown.",
+    )
+    parser_report_md.add_argument(
+        "input_file",
+        nargs="?",
+        default=DEFAULT_EVAL_RESULTS,
+        help=(
+            f"Arquivo JSON de entrada com os resultados da avaliação (padrão: {DEFAULT_EVAL_RESULTS})."
+        ),
+    )
+    parser_report_md.add_argument(
+        "output_file",
+        nargs="?",
+        default=DEFAULT_MD_REPORT,
+        help=(
+            f"Arquivo Markdown de saída para o relatório (padrão: {DEFAULT_MD_REPORT})."
+        ),
+    )
+    parser_report_md.add_argument(
+        "top_k_chunks",
+        nargs="?",
+        type=int,
+        default=5,
+        help="Valor de top_k_chunks usado na avaliação (para consistência do relatório, padrão: 5).",
+    )
 
     # --- Subparser para generate_report_html.py (HTML) ---
-    parser_report_html = subparsers.add_parser("report_html", help="Gera o relatório de cobertura em HTML.")
-    parser_report_html.add_argument("--input_file", default=DEFAULT_EVAL_RESULTS,
-                                    help=f"Arquivo JSON de entrada com os resultados da avaliação (padrão: {DEFAULT_EVAL_RESULTS}).")
-    parser_report_html.add_argument("--output_file", default=DEFAULT_HTML_REPORT,
-                                    help=f"Arquivo HTML de saída para o relatório (padrão: {DEFAULT_HTML_REPORT}).")
-    parser_report_html.add_argument("--top_k_chunks", type=int, default=5,
-                                    help="Valor de top_k_chunks usado na avaliação (para consistência do relatório, padrão: 5).")
+    parser_report_html = subparsers.add_parser(
+        "report_html",
+        help="Gera o relatório de cobertura em HTML.",
+    )
+    parser_report_html.add_argument(
+        "input_file",
+        nargs="?",
+        default=DEFAULT_EVAL_RESULTS,
+        help=(
+            f"Arquivo JSON de entrada com os resultados da avaliação (padrão: {DEFAULT_EVAL_RESULTS})."
+        ),
+    )
+    parser_report_html.add_argument(
+        "output_file",
+        nargs="?",
+        default=DEFAULT_HTML_REPORT,
+        help=(
+            f"Arquivo HTML de saída para o relatório (padrão: {DEFAULT_HTML_REPORT})."
+        ),
+    )
+    parser_report_html.add_argument(
+        "top_k_chunks",
+        nargs="?",
+        type=int,
+        default=5,
+        help="Valor de top_k_chunks usado na avaliação (para consistência do relatório, padrão: 5).",
+    )
 
     # --- Subparser para style_checker.py ---
     parser_style = subparsers.add_parser("style_check", help="Verifica o estilo de um texto.")

--- a/tests/test_docs_tc.py
+++ b/tests/test_docs_tc.py
@@ -38,7 +38,7 @@ def test_main_merge_invokes_run_script(monkeypatch, tmp_path):
     # Redirect config file to temp directory to avoid writing to real home
     monkeypatch.setattr(docs_tc, "CONFIG_DIR", tmp_path)
     monkeypatch.setattr(docs_tc, "CONFIG_FILE", tmp_path / "config.json")
-    monkeypatch.setattr(sys, "argv", ["docs_tc.py", "merge", "docsdir", "--output_file", "out.md"])
+    monkeypatch.setattr(sys, "argv", ["docs_tc.py", "merge", "docsdir", "out.md"])
     docs_tc.main()
     assert called["cmd"] == ["docs-tc-merge-markdown", "docsdir", "out.md"]
 


### PR DESCRIPTION
## Summary
- align CLI argument parsing in `docs_tc.py` with the scripts
- update README to document positional arguments
- fix tests for new CLI

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6874fd63b88c8333b5dbdf4e28ded779